### PR TITLE
Remove per application logfile property

### DIFF
--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Application.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Application.java
@@ -25,28 +25,16 @@ package org.springframework.cloud.dataflow.acceptance.test.util;
 public class Application {
 
 	protected String uri;
-	protected String logLocation;
 	protected String definition;
 
 	/**
 	 * Initializes the application instance.
-\	 * @param logLocation - the location where the the logs will be written
-	 * for this application.
+	 *
 	 * @param definition Establish the registered app name and the
 	 * required properties.
 	 */
-	public Application(String logLocation, String definition) {
-		this.logLocation = logLocation;
-		setDefinition(definition);
-	}
-
-	/**
-	 * Establish the registered app name and the required properties.
-	 * @param definition
-	 */
-	public void setDefinition (String definition) {
-		this.definition = String.format("%s --logging.file=%s",
-				definition, this.logLocation);
+	public Application(String definition) {
+		this.definition = definition;
 	}
 
 	/**

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalUriHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalUriHelper.java
@@ -55,7 +55,7 @@ public class LocalUriHelper implements UriHelper {
 		while (statsIterator.hasNext()) {
 			appStatus = statsIterator.next();
 			if (appStatus.getDeploymentId().contains(streamName)
-					&& appStatus.getDeploymentId().contains(getAppName(application.getDefinition()))){
+					&& appStatus.getDeploymentId().contains((application.getDefinition()))){
 				Iterator<AppInstanceStatusResource> resourceIterator =
 						appStatus.getInstances().iterator();
 				while (resourceIterator.hasNext()) {
@@ -70,12 +70,5 @@ public class LocalUriHelper implements UriHelper {
 		}
 	}
 
-	private String getAppName(String definition) {
-		definition = definition.trim();
-		if (definition.contains(" ")) {
-			definition = definition.substring(0, definition.indexOf(" "));
-		}
-		return definition;
-	}
 
 }

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Stream.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Stream.java
@@ -55,14 +55,12 @@ public class Stream {
 	}
 
 	/**
-	 * Sets the registered app name and its properties for the sink.  The default
-	 * log location will be added to the sink app properties.
-	 * @param definition the registered app name and its properties for the sink.
+	 * Sets the registered app name for the sink
+	 *
+	 * @param definition the registered app name
 	 */
-	public void setSink(String definition) {
-		String sinkLog = String.format("%s-%s",
-				streamName, "sink.txt");
-		sink = new Application(sinkLog , definition);
+	public void setSink(String definition) {;
+		sink = new Application(definition);
 	}
 
 	/**
@@ -74,14 +72,12 @@ public class Stream {
 	}
 
 	/**
-	 * Sets the registered app name and its properties for the source.  The
-	 * default log location will be added to the source app properties.
-	 * @param definition the registered app name and its properties for the source.
+	 * Sets the registered app name for the source.
+	 *
+	 * @param definition the registered app name
 	 */
 	public void setSource(String definition) {
-		String sourceLog = String.format("%s-%s",
-				streamName, "source.txt");
-		source = new Application(sourceLog, definition);
+		source = new Application(definition);
 	}
 
 	/**
@@ -125,9 +121,7 @@ public class Stream {
 	 */
 	public void addProcessor(String processorName, String definition) {
 		int processorCount = processors.size();
-		String log = String.format("%s-%s-%d.txt",
-				streamName, "processor", processorCount);
-		Application processor = new Application(log, definition);
+		Application processor = new Application(definition);
 		this.processors.put(processorName, processor);
 	}
 

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -27,8 +27,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties
 public class TestConfigurationProperties {
 
-	private String whatToTest = "CORE";
-
 	private int maxWaitTime = 30;
 
 	private String binder = "RABBIT";
@@ -44,14 +42,6 @@ public class TestConfigurationProperties {
 	private String platformSuffix = "local.pcfdev.io";
 
 	private String registrationResource;
-
-	public String getWhatToTest() {
-		return whatToTest;
-	}
-
-	public void setWhatToTest(String whatToTest) {
-		this.whatToTest = whatToTest;
-	}
 
 	public int getMaxWaitTime() {
 		return maxWaitTime;

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -19,9 +19,7 @@ package org.springframework.cloud.dataflow.acceptance.test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -179,8 +177,10 @@ public abstract class AbstractStreamTests implements InitializingBean {
 	 * @param stream the stream object containing the stream definition.
 	 */
 	protected void deployStream(Stream stream) {
-		streamOperations.createStream(stream.getStreamName(),
-				stream.getDefinition(), true);
+		streamOperations.createStream(stream.getStreamName(),stream.getDefinition(), false);
+		Map<String, String> streamProperties = new HashMap<>();
+		streamProperties.put("app.*.logging.file", "${PID}");
+		streamOperations.deploy(stream.getStreamName(), streamProperties);
 		streamAvailable(stream.getStreamName());
 		uriHelper.setUrisForStream(stream);
 	}

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -34,12 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.dataflow.acceptance.test.util.Application;
-import org.springframework.cloud.dataflow.acceptance.test.util.CloudFoundryUriHelper;
-import org.springframework.cloud.dataflow.acceptance.test.util.LocalUriHelper;
-import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
-import org.springframework.cloud.dataflow.acceptance.test.util.TestConfigurationProperties;
-import org.springframework.cloud.dataflow.acceptance.test.util.UriHelper;
+import org.springframework.cloud.dataflow.acceptance.test.util.*;
 import org.springframework.cloud.dataflow.rest.client.AppRegistryOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
 import org.springframework.cloud.dataflow.rest.client.RuntimeOperations;
@@ -48,8 +43,6 @@ import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
-
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Abstract base class that is used by stream acceptance tests.  This class
@@ -60,8 +53,6 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(SpringRunner.class)
 @EnableConfigurationProperties(TestConfigurationProperties.class)
 public abstract class AbstractStreamTests implements InitializingBean {
-
-	public enum StreamTestTypes {HTTP_SOURCE, TAP, TICKTOCK, TRANSFORM, CORE}
 
 	public enum PlatformTypes {LOCAL, CLOUD_FOUNDRY}
 
@@ -139,15 +130,6 @@ public abstract class AbstractStreamTests implements InitializingBean {
 	@Before
 	public void setup() {
 		registerApps();
-		boolean isTestable = false;
-		for(StreamTestTypes type : getTarget()) {
-			if(type.toString().equals(configurationProperties.getWhatToTest()))
-			{
-				isTestable = true;
-				break;
-			}
-		}
-		assumeTrue(isTestable);
 	}
 
 	/**
@@ -339,8 +321,4 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		return exists;
 	}
 
-	/**
-	 * Return a list of targets this test should be associated with
-	 */
-	public abstract List<StreamTestTypes> getTarget();
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
@@ -2,12 +2,7 @@ package org.springframework.cloud.dataflow.acceptance.test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -26,8 +21,6 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
-
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Abstract base class that is used by task acceptance tests.  This class
@@ -53,15 +46,6 @@ public abstract class AbstractTaskTests implements InitializingBean {
 
 	@Before
 	public void setup() {
-		boolean isTestable = false;
-		for(TaskTestTypes type :getTarget()) {
-			if(type.toString().equals(configurationProperties.getWhatToTest()))
-			{
-				isTestable = true;
-				break;
-			}
-		}
-		assumeTrue(isTestable);
 		registerApps();
 	}
 
@@ -222,10 +206,5 @@ public abstract class AbstractTaskTests implements InitializingBean {
 		}
 		return result;
 	}
-
-	/**
-	 * Return a list of targets this test should be associated with
-	 */
-	public abstract List<TaskTestTypes> getTarget();
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.acceptance.test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -44,11 +42,4 @@ public class HttpSourceTests extends AbstractStreamTests {
 		waitForLogEntry(stream.getSink(), testVal);
 	}
 
-	@Override
-	public List<StreamTestTypes> getTarget() {
-		List<StreamTestTypes> types = new ArrayList<>();
-		types.add(StreamTestTypes.HTTP_SOURCE);
-		types.add(StreamTestTypes.CORE);
-		return types;
-	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.dataflow.acceptance.test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
@@ -63,10 +60,4 @@ public class TapTests extends AbstractStreamTests{
 		waitForLogEntry(tapStream.getSink(), "] log.sink");
 	}
 
-	@Override
-	public List<StreamTestTypes> getTarget() {
-		List<StreamTestTypes> types = new ArrayList<>();
-		types.add(StreamTestTypes.TAP);
-		return types;
-	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.dataflow.acceptance.test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
@@ -41,11 +38,4 @@ public class TickTockTests extends AbstractStreamTests {
 		waitForLogEntry(stream.getSink(), "] log.sink");
 	}
 
-	@Override
-	public List<StreamTestTypes> getTarget() {
-		List<StreamTestTypes> types = new ArrayList<>();
-		types.add(StreamTestTypes.TICKTOCK);
-		types.add(StreamTestTypes.CORE);
-		return types;
-	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TimestampTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TimestampTaskTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.acceptance.test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -30,7 +29,7 @@ import static org.junit.Assert.assertTrue;
  * Executes acceptance tests for the timestamp task.
  * @author Glenn Renfro
  */
-public class TimestampTaskTests extends AbstractTaskTests{
+public class TimestampTaskTests extends AbstractTaskTests {
 
 	@Test
 	public void timeStampTests() {
@@ -61,14 +60,6 @@ public class TimestampTaskTests extends AbstractTaskTests{
 		for(TaskExecutionResource taskExecutionResource : taskExecutionResources) {
 			assertEquals(expectedExitCode, taskExecutionResource.getExitCode());
 		}
-	}
-
-	@Override
-	public List<AbstractTaskTests.TaskTestTypes> getTarget() {
-		List<AbstractTaskTests.TaskTestTypes> types = new ArrayList<>();
-		types.add(AbstractTaskTests.TaskTestTypes.TIMESTAMP);
-		types.add(AbstractTaskTests.TaskTestTypes.CORE);
-		return types;
 	}
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.dataflow.acceptance.test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
@@ -47,10 +44,4 @@ public class TransformTests extends AbstractStreamTests{
 		waitForLogEntry(stream.getSink(), "ABCDEFG");
 	}
 
-	@Override
-	public List<StreamTestTypes> getTarget() {
-		List<StreamTestTypes> types = new ArrayList<>();
-		types.add(StreamTestTypes.TRANSFORM);
-		return types;
-	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/ApplicationTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/ApplicationTests.java
@@ -28,28 +28,22 @@ import static org.junit.Assert.assertEquals;
 public class ApplicationTests {
 
 	public static final String DEFAULT_URI = "http://myURI";
-	public static final String DEFAULT_LOG_FILE_URI = "file://foo";
 
 	@Test
 	public void testApplication() {
-		Application application = new Application(DEFAULT_LOG_FILE_URI, "BAR");
+		Application application = new Application( "BAR");
 		application.setUri(DEFAULT_URI);
-		validateApplication(application, DEFAULT_LOG_FILE_URI, "BAR",
-				DEFAULT_URI);
+		validateApplication(application, "BAR", 	DEFAULT_URI);
 	}
 	@Test
 	public void testApplicationParam() {
-		Application application = new Application(DEFAULT_LOG_FILE_URI,
-				"BAR --BAZ=FOO");
+		Application application = new Application("BAR --BAZ=FOO");
 		application.setUri(DEFAULT_URI);
-		validateApplication(application, DEFAULT_LOG_FILE_URI, "BAR --BAZ=FOO",
-				DEFAULT_URI);
+		validateApplication(application, "BAR --BAZ=FOO", DEFAULT_URI);
 	}
 
-	private void validateApplication(Application application,
-			String logFileUri, String definition, String uri) {
-		assertEquals(String.format("%s --logging.file=%s", definition,
-				logFileUri), application.getDefinition());
+	private void validateApplication(Application application, String definition, String uri) {
+		assertEquals(definition, application.getDefinition());
 		assertEquals(uri, application.getUri());
 	}
 

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/UriHelperTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/UriHelperTests.java
@@ -24,13 +24,13 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
 import org.springframework.cloud.dataflow.rest.client.RuntimeOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedResources;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro


### PR DESCRIPTION
Use deployment property `app.*.logging.file=${PID}` instead

Fixes #29 

Merge the PR https://github.com/spring-cloud/spring-cloud-dataflow-acceptance-tests/pull/32 first.  

Actually I notice this PR also has those changes ... doh.

