### PR TITLE
Make TickTockTests work on Cloud Foundry

### DIFF
--- a/cloudfoundry/server/create.sh
+++ b/cloudfoundry/server/create.sh
@@ -35,6 +35,7 @@ function push_application() {
   SERVER_URI="http://$SERVER_URI"
   echo "SCDF SERVER URI: $SERVER_URI"
   export SERVER_URI
+  export PLATFORM_SUFFIX=$SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN
   rm -f scdf-manifest.yml
 }
 

--- a/local/server/create.sh
+++ b/local/server/create.sh
@@ -13,6 +13,6 @@ function java_jar() {
     $(netcat_port localhost 9393)
     return 0
 }
-export APPLICATION_ARGS="$APPLICATION_ARGS --spring.cloud.dataflow.applicationProperties.stream.security.basic.enabled=false --spring.cloud.dataflow.applicationProperties.stream.management.security.enabled=false"
+export APPLICATION_ARGS="$APPLICATION_ARGS --spring.cloud.dataflow.applicationProperties.stream.security.basic.enabled=false"
 download $PWD
 java_jar $PWD

--- a/run.sh
+++ b/run.sh
@@ -99,7 +99,7 @@ function tear_down() {
 }
 
 function run_tests() {
-   eval "./mvnw -Dtest=$TESTS  test"
+   eval "./mvnw -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM test"
 }
 
 # ======================================= FUNCTIONS END =======================================
@@ -155,6 +155,7 @@ shift
 done
 
 # ======================================= DEFAULTS ============================================
+[[ -z "${PLATFORM}" ]] && PLATFORM=local
 [[ -z "${BINDER}" ]] && BINDER=rabbit
 WAIT_TIME="${WAIT_TIME:-5}"
 RETRIES="${RETRIES:-6}"
@@ -163,6 +164,7 @@ MEM_ARGS="-Xmx1024m -Xss1024k"
 JAVA_OPTS=""
 APPLICATION_ARGS=""
 # ======================================= DEFAULTS END ========================================
+[[ ! -d "$PLATFORM" ]] && { echo "$PLATFORM is an invalid platform"; exit 1; }
 
 if [ -z "$skipSetup" ]; then
   setup

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/CloudFoundryPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/CloudFoundryPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,14 +23,15 @@ import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 
 /**
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
-public class CloudFoundryUriHelper implements UriHelper {
+public class CloudFoundryPlatformHelper implements PlatformHelper {
 
 	private RuntimeOperations operations;
 
 	private String cfSuffix;
 
-	public CloudFoundryUriHelper(RuntimeOperations operations, String cfSuffix) {
+	public CloudFoundryPlatformHelper(RuntimeOperations operations, String cfSuffix) {
 		this.operations = operations;
 		this.cfSuffix = cfSuffix;
 	}
@@ -49,6 +50,11 @@ public class CloudFoundryUriHelper implements UriHelper {
 						appStatus);
 			}
 		}
+	}
+
+	@Override
+	public String getLogfileName() {
+		return "test.log";
 	}
 
 	private void setUriForApplication(String streamName, String cfSuffix,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,14 +25,15 @@ import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 
 /**
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
-public class LocalUriHelper implements UriHelper {
+public class LocalPlatformHelper implements PlatformHelper {
 
 	private final String URL = "url";
 
 	private RuntimeOperations operations;
 
-	public LocalUriHelper(RuntimeOperations operations) {
+	public LocalPlatformHelper(RuntimeOperations operations) {
 		this.operations = operations;
 	}
 
@@ -47,6 +48,11 @@ public class LocalUriHelper implements UriHelper {
 		for (Application processor : stream.getProcessors().values()) {
 			setAppUri(stream.getStreamName(), processor);
 		}
+	}
+
+	@Override
+	public String getLogfileName() {
+		return "${PID}";
 	}
 
 	private void setAppUri(String streamName, Application application) {

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,12 +19,18 @@ package org.springframework.cloud.dataflow.acceptance.test.util;
 /**
  * Methods that help retrieve app uri information for a specific platform.
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
-public interface UriHelper {
+public interface PlatformHelper {
 
 	/**
 	 * Identifies and sets the uri for each app in a stream.
 	 * @param stream the stream to augment.
 	 */
-	public void setUrisForStream(Stream stream);
+	void setUrisForStream(Stream stream);
+
+	/**
+	 * Returns the logfile name to use.
+	 */
+	String getLogfileName();
 }

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * a Spring Cloud Data Flow Server and the associated binder.
  *
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
 @ConfigurationProperties
 public class TestConfigurationProperties {

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,9 +22,12 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Executes acceptance tests for the http source app as a part of a stream.
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
 
 public class HttpSourceTests extends AbstractStreamTests {
@@ -35,11 +38,12 @@ public class HttpSourceTests extends AbstractStreamTests {
 		stream.setSink("log");
 		stream.setSource("http");
 		stream.setDefinition(stream.getSource() + " | " +stream.getSink());
-
 		deployStream(stream);
 		String testVal = UUID.randomUUID().toString();
+		assertTrue("Source not started", waitForLogEntry(stream.getSource(), "Started HttpSource"));
 		httpPostData(stream.getSource(), testVal);
-		waitForLogEntry(stream.getSink(), testVal);
+		assertTrue("Sink not started", waitForLogEntry(stream.getSink(), "Started LogSink"));
+		assertTrue("No output found", waitForLogEntry(stream.getSink(), testVal));
 	}
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Executes acceptance tests for the for obtaining messages from a tap and
  * a destination.
@@ -39,8 +41,8 @@ public class TapTests extends AbstractStreamTests{
 		timeStream.setDefinition(timeStream.getSource() + " > :DESTINATION1");
 		deployStream(timeStream);
 
-		waitForLogEntry(logStream.getSink(), "Started LogSinkRabbitApplication");
-		waitForLogEntry(logStream.getSink(), "] log.sink");
+		assertTrue("Sink not started", waitForLogEntry(logStream.getSink(), "Started LogSink"));
+		assertTrue("No output found", waitForLogEntry(logStream.getSink(), ".DESTINATION1-"));
 	}
 
 	@Test
@@ -56,8 +58,8 @@ public class TapTests extends AbstractStreamTests{
 		tapStream.setDefinition(" :TAPTOCK.time > " +tapStream.getSink());
 		deployStream(tapStream);
 
-		waitForLogEntry(tapStream.getSink(), "Started LogSinkRabbitApplication");
-		waitForLogEntry(tapStream.getSink(), "] log.sink");
+		assertTrue("Sink not started", waitForLogEntry(tapStream.getSink(), "Started LogSink"));
+		assertTrue("No output found", waitForLogEntry(tapStream.getSink(), "time.TAPSTREAM-"));
 	}
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,9 +20,12 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Executes acceptance tests for the ticktock demo.
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
 
 public class TickTockTests extends AbstractStreamTests {
@@ -34,8 +37,9 @@ public class TickTockTests extends AbstractStreamTests {
 		stream.setSource("time");
 		stream.setDefinition(stream.getSource() + " | " +stream.getSink());
 		deployStream(stream);
-		waitForLogEntry(stream.getSink(), "Started LogSinkRabbitApplication");
-		waitForLogEntry(stream.getSink(), "] log.sink");
+		assertTrue("Source not started", waitForLogEntry(stream.getSource(), "Started TimeSource"));
+		assertTrue("Sink not started", waitForLogEntry(stream.getSink(), "Started LogSink"));
+		assertTrue("No output found", waitForLogEntry(stream.getSink(), "time.TICKTOCK-"));
 	}
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.acceptance.test.util.Stream;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Executes acceptance tests for the transform processor app as a part of a stream.
  * @author Glenn Renfro
@@ -40,8 +42,10 @@ public class TransformTests extends AbstractStreamTests{
 
 		deployStream(stream);
 
+		assertTrue("Source not started", waitForLogEntry(stream.getSource(), "Started HttpSource"));
 		httpPostData(stream.getSource(), "abcdefg");
-		waitForLogEntry(stream.getSink(), "ABCDEFG");
+		assertTrue("Sink not started", waitForLogEntry(stream.getSink(), "Started LogSink"));
+		assertTrue("No output found", waitForLogEntry(stream.getSink(), "ABCDEFG"));
 	}
 
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelperTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -34,15 +34,16 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
-public class UriHelperTests {
+public class PlatformHelperTests {
 
 	private String STREAM_NAME = "teststream";
 
 	@Mock
 	private RuntimeOperations runtimeOperations;
 
-	private UriHelper uriHelper;
+	private PlatformHelper platformHelper;
 
 	@Before
 	public void setUp() {
@@ -60,11 +61,11 @@ public class UriHelperTests {
 		Stream stream = new Stream(STREAM_NAME);
 		stream.setSource("time");
 		stream.setSink("log");
-		uriHelper = new LocalUriHelper(runtimeOperations);
-		uriHelper.setUrisForStream(stream);
-		assertEquals("time --logging.file=teststream-source.txt", stream.getSource().getDefinition());
-		assertEquals("log --logging.file=teststream-sink.txt", stream.getSink().getDefinition());
-		System.out.println(stream.getSource().getUri());
+		platformHelper = new LocalPlatformHelper(runtimeOperations);
+		platformHelper.setUrisForStream(stream);
+		assertEquals("time", stream.getSource().getDefinition());
+		assertEquals("log", stream.getSink().getDefinition());
+		assertEquals("${PID}", platformHelper.getLogfileName());
 	}
 
 	@Test
@@ -72,10 +73,10 @@ public class UriHelperTests {
 		Stream stream = new Stream("teststream");
 		stream.setSource("time");
 		stream.setSink("log");
-		uriHelper = new CloudFoundryUriHelper(runtimeOperations, "TESTSUFFIX");
-		uriHelper.setUrisForStream(stream);
-		assertEquals("time --logging.file=teststream-source.txt", stream.getSource().getDefinition());
-		assertEquals("log --logging.file=teststream-sink.txt", stream.getSink().getDefinition());
-		System.out.println(stream.getSource().getUri());
+		platformHelper = new CloudFoundryPlatformHelper(runtimeOperations, "TESTSUFFIX");
+		platformHelper.setUrisForStream(stream);
+		assertEquals("time", stream.getSource().getDefinition());
+		assertEquals("log", stream.getSink().getDefinition());
+		assertEquals("test.log", platformHelper.getLogfileName());
 	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/StreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/StreamTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
  * Verifies the basic functionality of the Stream util.
  *
  * @author Glenn Renfro
+ * @author Thomas Risberg
  */
 public class StreamTests {
 
@@ -33,8 +34,7 @@ public class StreamTests {
 		stream.setSink("BAR");
 		stream.setSource("FOO");
 		stream.setDefinition(stream.getSource() + " | " + stream.getSink());
-		assertEquals ("FOO --logging.file=test1-source.txt | BAR "
-				+ "--logging.file=test1-sink.txt", stream.getDefinition());
+		assertEquals ("FOO | BAR", stream.getDefinition());
 	}
 
 	@Test
@@ -46,9 +46,7 @@ public class StreamTests {
 		stream.setDefinition(stream.getSource() + " | " +
 				stream.getProcessors().get("BAZ") + " | " +
 				stream.getSink());
-		assertEquals ("FOO --logging.file=test2-source.txt "
-				+ "| BAZBAZ --logging.file=test2-processor-0.txt "
-				+ "| BAR --logging.file=test2-sink.txt", stream.getDefinition());
+		assertEquals ("FOO | BAZBAZ | BAR", stream.getDefinition());
 	}
 
 	@Test
@@ -56,8 +54,7 @@ public class StreamTests {
 		Stream stream = new Stream("test3");
 		stream.setSink("BAR");
 		stream.setDefinition(":WOMBAT.time > " + stream.getSink());
-		assertEquals (":WOMBAT.time > BAR "
-				+ "--logging.file=test3-sink.txt", stream.getDefinition());
+		assertEquals (":WOMBAT.time > BAR", stream.getDefinition());
 	}
 
 }


### PR DESCRIPTION
- set platform to local by default

- pass in platform to tests

- update test config and AbstractStreamTests to work on Cloud Foundry

- update TickTock to work on Cloud Foundry

Resolves #51