### PR TITLE
Get tests to pass with kafka as binder

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -99,7 +99,7 @@ function tear_down() {
 }
 
 function run_tests() {
-   eval "./mvnw clean -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM surefire-report:report"
+   eval "./mvnw clean -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM test surefire-report:report"
 }
 
 # ======================================= FUNCTIONS END =======================================

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -171,13 +171,14 @@ public abstract class AbstractStreamTests implements InitializingBean {
 	 * @param stream the stream object containing the stream definition.
 	 */
 	protected void deployStream(StreamDefinition stream) {
-		logger.info("Deploying stream '" + stream.getName() + "'");
+		logger.info("Creating stream '" + stream.getName() + "'");
 		streamOperations.createStream(stream.getName(),stream.getDefinition(), false);
 		Map<String, String> streamProperties = new HashMap<>();
 		streamProperties.put("app.*.logging.file", platformHelper.getLogfileName());
 		streamProperties.put("app.*.endpoints.logfile.sensitive", "false");
 
 		streamProperties.putAll(stream.getDeploymentProperties());
+		logger.info("Deploying stream '" + stream.getName() + "' with properties: " + streamProperties);
 		streamOperations.deploy(stream.getName(), streamProperties);
 		streamAvailable(stream.getName());
 		platformHelper.setUrisForStream(stream);

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TapTests.java
@@ -34,6 +34,7 @@ public class TapTests extends AbstractStreamTests{
 	public void testDestination() {
 		StreamDefinition logStream = StreamDefinition.builder("DESTINATION1")
 				.definition(":DESTINATION1 > log")
+				.addProperty("app.log.log.expression","'DESTINATION1 - TIMESTAMP: '.concat(payload)")
 				.build();
 		deployStream(logStream);
 
@@ -42,9 +43,8 @@ public class TapTests extends AbstractStreamTests{
 				.build();
 		deployStream(timeStream);
 
-
 		assertTrue("Sink not started", waitForLogEntry(logStream.getApplication("log"), "Started LogSink"));
-		assertTrue("No output found", waitForLogEntry(logStream.getApplication("log"), ".DESTINATION1-"));
+		assertTrue("No output found", waitForLogEntry(logStream.getApplication("log"), "DESTINATION1 - TIMESTAMP:"));
 
 	}
 
@@ -57,10 +57,11 @@ public class TapTests extends AbstractStreamTests{
 
 		StreamDefinition tapStream = StreamDefinition.builder("TAPSTREAM")
 				.definition(":TAPTOCK.time > log")
+				.addProperty("app.log.log.expression","'TAPSTREAM - TIMESTAMP: '.concat(payload)")
 				.build();
 		deployStream(tapStream);
 		assertTrue("Sink not started", waitForLogEntry(tapStream.getApplication("log"), "Started LogSink"));
-		assertTrue("No output found", waitForLogEntry(tapStream.getApplication("log"), "time.TAPSTREAM-"));
+		assertTrue("No output found", waitForLogEntry(tapStream.getApplication("log"), "TAPSTREAM - TIMESTAMP:"));
 
 	}
 

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
@@ -35,12 +35,14 @@ public class TickTockTests extends AbstractStreamTests {
 	@Test
 	public void tickTockTests() {
 		StreamDefinition stream = StreamDefinition.builder("TICKTOCK")
-				.definition("time | log").build();
+				.definition("time | log")
+				.addProperty("app.log.log.expression","'TICKTOCK - TIMESTAMP: '.concat(payload)")
+				.build();
 
 		deployStream(stream);
 		assertTrue("Source not started", waitForLogEntry(stream.getApplication("time"), "Started TimeSource"));
 		assertTrue("Sink not started", waitForLogEntry(stream.getApplication("log"), "Started LogSink"));
-		assertTrue("No output found", waitForLogEntry(stream.getApplication("log"), "time.TICKTOCK-"));
+		assertTrue("No output found", waitForLogEntry(stream.getApplication("log"), "TICKTOCK - TIMESTAMP:"));
 	}
 
 }


### PR DESCRIPTION
- change the way we check logs for new entries from sink

- add back test target for mvn commmand to make a failed tests get reported as BUILD FAILURE

Resolves #28
Resolves #67