### PR TITLE
Fix output from netcat port check

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -44,7 +44,7 @@ done < "$filename"
 }
 
 function test_port() {
-  nc -w1 ${1} $2 </dev/null
+  nc -w1 ${1} $2 >/dev/null
 }
 
 function netcat_port() {


### PR DESCRIPTION
- Change netcat output handling so that
  socket data is not processed in a bash.
- Fixes #114