### PR TITLE
Fixed env var naming with statefulsets

### DIFF
--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/WoodChuckTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/WoodChuckTests.java
@@ -38,7 +38,7 @@ public class WoodChuckTests extends AbstractStreamTests {
 				.addProperty("deployer.log.count", "2")
 				.addProperty("app.splitter.producer.partitionKeyExpression", "payload")
 				.addProperty("app.log.spring.cloud.stream.kafka.bindings.input.consumer.autoRebalanceEnabled", "false")
-				.addProperty("app.log.logging.pattern.level", "WOODCHUCK-${instance.index} %5p")
+				.addProperty("app.log.logging.pattern.level", "WOODCHUCK-${INSTANCE_INDEX} %5p")
 				.build();
 		deployStream(stream);
 


### PR DESCRIPTION
With new initContainer only `INSTANCE_INDEX` seems to be available on the env and not `instance.index` 