### PR TITLE
Map Kafka creds in Skipper's SAJ

### DIFF
--- a/kubernetes/skipper-server/skipper.yml
+++ b/kubernetes/skipper-server/skipper.yml
@@ -38,7 +38,7 @@ spec:
         - name: SERVER_PORT
           value: '7577'
         - name: SPRING_APPLICATION_JSON
-          value: "{\"spring.cloud.skipper.server.enableLocalPlatform\" : false, \"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.environmentVariables\" : \"SPRING_RABBITMQ_HOST=${RABBITMQ_SERVICE_HOST},SPRING_RABBITMQ_PORT=${RABBITMQ_SERVICE_PORT}\",\"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.memory\" : \"1024Mi\",\"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.createDeployment\" : true}"
+          value: "{\"spring.cloud.skipper.server.enableLocalPlatform\" : false, \"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.environmentVariables\" : \"SPRING_RABBITMQ_HOST=${RABBITMQ_SERVICE_HOST},SPRING_RABBITMQ_PORT=${RABBITMQ_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${KAFKA_SERVICE_HOST}:${KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${KAFKA_ZK_SERVICE_HOST}:${KAFKA_ZK_SERVICE_PORT}\",\"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.memory\" : \"1024Mi\",\"spring.cloud.skipper.server.platform.kubernetes.accounts.cluster1.createDeployment\" : true}"
 
 ---
 


### PR DESCRIPTION
Currently, in Skipper-mode, the Kafka ATs are failing because the apps don't receive Kafka creds. This PR adds the mapping for Kafka similar to what we have done for Rabbit.