### PR TITLE
Replace bit.ly with spring-repo links

### DIFF
--- a/cloudfoundry/binder/rabbit/env.properties
+++ b/cloudfoundry/binder/rabbit/env.properties
@@ -1,2 +1,2 @@
-STREAM_REGISTRATION_RESOURCE=http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
-TASK_REGISTRATION_RESOURCE=http://bit.ly/Clark-GA-task-applications-maven
+STREAM_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-rabbit-maven
+TASK_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.RELEASE/spring-cloud-task-app-descriptor-Clark.RELEASE.task-apps-maven

--- a/kubernetes/binder/kafka/env.properties
+++ b/kubernetes/binder/kafka/env.properties
@@ -1,2 +1,2 @@
-STREAM_REGISTRATION_RESOURCE=http://bit.ly/Celsius-SR1-stream-applications-kafka-10-docker
-TASK_REGISTRATION_RESOURCE=http://bit.ly/Clark-GA-task-applications-docker
+STREAM_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-kafka-10-docker
+TASK_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.RELEASE/spring-cloud-task-app-descriptor-Clark.RELEASE.task-apps-docker

--- a/kubernetes/binder/rabbit/env.properties
+++ b/kubernetes/binder/rabbit/env.properties
@@ -1,2 +1,2 @@
-STREAM_REGISTRATION_RESOURCE=http://bit.ly/Celsius-SR1-stream-applications-rabbit-docker
-TASK_REGISTRATION_RESOURCE=http://bit.ly/Clark-GA-task-applications-docker
+STREAM_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-rabbit-docker
+TASK_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.RELEASE/spring-cloud-task-app-descriptor-Clark.RELEASE.task-apps-docker

--- a/local/binder/kafka/env.properties
+++ b/local/binder/kafka/env.properties
@@ -1,2 +1,2 @@
-STREAM_REGISTRATION_RESOURCE=http://bit.ly/Celsius-SR1-stream-applications-kafka-10-maven
-TASK_REGISTRATION_RESOURCE=http://bit.ly/Clark-GA-task-applications-maven
+STREAM_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-kafka-10-maven
+TASK_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.RELEASE/spring-cloud-task-app-descriptor-Clark.RELEASE.task-apps-maven

--- a/local/binder/rabbit/env.properties
+++ b/local/binder/rabbit/env.properties
@@ -1,2 +1,2 @@
-STREAM_REGISTRATION_RESOURCE=http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
-TASK_REGISTRATION_RESOURCE=http://bit.ly/Clark-GA-task-applications-maven
+STREAM_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-rabbit-maven
+TASK_REGISTRATION_RESOURCE=http://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.RELEASE/spring-cloud-task-app-descriptor-Clark.RELEASE.task-apps-maven

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -42,9 +42,9 @@ public class TestConfigurationProperties {
 
 	private String platformSuffix = "local.pcfdev.io";
 
-	private String streamRegistrationResource = "http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-rabbit-maven";
+	private String streamRegistrationResource = "http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.BUILD-SNAPSHOT/spring-cloud-stream-app-descriptor-Celsius.BUILD-SNAPSHOT.stream-apps-rabbit-maven";
 
-	private String taskRegistrationResource = "http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-maven";
+	private String taskRegistrationResource = "http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Clark.BUILD-SNAPSHOT/spring-cloud-task-app-descriptor-Clark.BUILD-SNAPSHOT.task-apps-maven";
 
 	public int getMaxWaitTime() {
 		return maxWaitTime;


### PR DESCRIPTION
The goal of this proposal is to prevent the cf/k8s acceptance test failures due to rate limiting of bit.ly links.

Resolves spring-cloud/spring-cloud-dataflow-acceptance-tests#155