### PR TITLE
 Add support to save the logs in local mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ spring-shell.log
 target/
 test-output
 dataflowlib/
+app-logs/
 *.pid
 *.jar
 *.log

--- a/local/server/create.sh
+++ b/local/server/create.sh
@@ -20,5 +20,12 @@ if [  ! -z "$skipperMode" ]; then
  APPLICATION_ARGS="$APPLICATION_ARGS --spring.cloud.dataflow.features.skipper-enabled=true"
 fi
 
+if [  -z "$skipperMode" ]; then
+ APP_LOG_PATH=$PWD/app-logs
+ rm -rf $APP_LOG_PATH
+ mkdir $APP_LOG_PATH
+ APPLICATION_ARGS="$APPLICATION_ARGS --spring.cloud.deployer.local.workingDirectoriesRoot=$APP_LOG_PATH"
+fi
+
 download $PWD
 java_jar $PWD

--- a/local/skipper-server/config.sh
+++ b/local/skipper-server/config.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-export APPLICATION_ARGS="$APPLICATION_ARGS"
+APP_LOG_PATH=$PWD/app-logs
+export APPLICATION_ARGS="$APPLICATION_ARGS --spring.cloud.skipper.server.platform.local.accounts.default.workingDirectoriesRoot=$APP_LOG_PATH"
 SKIPPER_SERVER_URI="http://localhost:7577"
 echo "SKIPPER SERVER URI: $SKIPPER_SERVER_URI"
 export SKIPPER_SERVER_URI

--- a/local/skipper-server/create.sh
+++ b/local/skipper-server/create.sh
@@ -16,5 +16,11 @@ function java_jar() {
 
 run_scripts "$PWD" "config.sh"
 
+if [  ! -z "$skipperMode" ]; then
+ APP_LOG_PATH=$PWD/app-logs
+ rm -rf $APP_LOG_PATH
+ mkdir $APP_LOG_PATH
+fi
+
 download_skipper $PWD
 java_jar $PWD

--- a/run.sh
+++ b/run.sh
@@ -74,7 +74,7 @@ function download(){
     echo "Downloading server from $SPRING_CLOUD_DATAFLOW_SERVER_DOWNLOAD_URL"
     wget $SPRING_CLOUD_DATAFLOW_SERVER_DOWNLOAD_URL --no-verbose -O $1/scdf-server.jar
   else
-    echo "Using already downloaded server, waiting for services to start ..."
+    echo "Using already downloaded server, waiting for server to start ..."
     sleep 15
   fi
 }
@@ -87,7 +87,7 @@ function download_skipper(){
     echo "Downloading server from $SPRING_CLOUD_SKIPPER_SERVER_DOWNLOAD_URL"
     wget $SPRING_CLOUD_SKIPPER_SERVER_DOWNLOAD_URL --no-verbose -O $1/skipper-server.jar
   else
-    echo "Using already downloaded server, waiting for services to start ..."
+    echo "Using already downloaded server, waiting for server to start ..."
     sleep 15
   fi
 }

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/AbstractPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/AbstractPlatformHelper.java
@@ -41,6 +41,8 @@ public abstract class AbstractPlatformHelper implements PlatformHelper {
 	@Override
 	public boolean setUrlsForStream(StreamDefinition stream) {
 		Iterator<AppStatusResource> statsIterator = operations.status().iterator();
+		int numberOfAppsInStream = stream.getApplications().size();
+		int numberOfAppsWithUrls = 0;
 		while (statsIterator.hasNext()) {
 			AppStatusResource appStatus = statsIterator.next();
 			for (Application application : stream.getApplications()) {
@@ -51,11 +53,15 @@ public abstract class AbstractPlatformHelper implements PlatformHelper {
 					}
 					else {
 						setInstanceUrlsForApplication(application, appStatus);
+						numberOfAppsWithUrls++;
 					}
 				}
 			}
 		}
-		return true;
+		if (numberOfAppsInStream == numberOfAppsWithUrls) {
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Keep application logs in the working directory of the server that deploys apps

* Also fixes #171 and fixes #170 - that ensures all app URLs are available before attempting to access log files