### PR TITLE
Add endpoint configs for boot2 apps

### DIFF
--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -151,7 +151,11 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		streamOperations.createStream(stream.getName(), stream.getDefinition(), false);
 		Map<String, String> streamProperties = new HashMap<>();
 		streamProperties.put("app.*.logging.file", platformHelper.getLogfileName());
+		// for boot1
 		streamProperties.put("app.*.endpoints.logfile.sensitive", "false");
+		// for boot2
+		streamProperties.put("app.*.management.endpoints.web.exposure.include", "*");
+		streamProperties.put("app.*.management.endpoints.web.base-path", "/");
 		platformHelper.addDeploymentProperties(stream, streamProperties);
 
 		streamProperties.putAll(stream.getDeploymentProperties());


### PR DESCRIPTION
As `Darwin.SR2` apps we need to change boot2 related configs are some tests are failing with message `Failed to access logfile from 'http://10.194.6.17:9310/logfile' due to : 404 null`