### PR TITLE
make service management for CloudFoundry blocking

### DIFF
--- a/cloudfoundry/common.sh
+++ b/cloudfoundry/common.sh
@@ -1,16 +1,84 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+function timestamp() {
+  date +"%Y-%m-%d %T"
+}
+
+function msg() {
+  echo -en "\033[38;5;0m"       # black foreground
+  echo -en '\033[48;5;2m'       # green backround
+  echo -n "--- [$(timestamp)] $@"
+  echo -en '\033[0m'            # reset
+  echo
+}
+
+function err() {
+  echo -en "\033[38;5;7m"       # white foreground
+  echo -en '\033[48;5;1m'       # red background
+  echo -n "!!! [$(timestamp)] $@"
+  echo -en '\033[0m'            # reset
+  echo
+}
+
+die() {
+  err $@
+  exit 1
+}
 
 function create_service() {
-  SCDF_SERVICE_NAME=$1
-  SERVICE_NAME=$2
-  PLAN_NAME=$3
-  if ! (cf services | grep "^$SCDF_SERVICE_NAME"); then
-    cf cs $SERVICE_NAME $PLAN_NAME $SCDF_SERVICE_NAME
-  fi
+  local service=$1
+  local service_type=$2
+  local service_plan=$3
+  local count=0
+  local service_info=
+  while [ 1 ]; do
+    if ! service_info=$(cf service  "$service" 2>&1); then
+      msg "creating service $service [$service_type/$service_plan]"
+      cf create-service $service_type $service_plan $service
+      continue
+    fi
+    if [[ $service_info == *"create succeeded"* ]]; then
+      break
+    fi
+    if [[ $service_info == *"delete in progress"* ]]; then
+      die "cannot create service $service; it is in the process of being deleted"
+    fi
+    count=$((count+1))
+    if [[ $service_info == *"create in progress"* ]]; then
+      msg "waiting for service $service to be created ($count)"
+    else
+      err "unhandled status:"
+      echo $service_info
+    fi
+    sleep 1
+  done
 }
 
 function destroy_service() {
-  if (cf services | grep "^$1"); then
-    cf ds $1 -f
-  fi
+  local service=$1
+  local count=0
+  local service_info=
+  while [ 1 ]; do
+    if ! service_info=$(cf service  "$service" 2>&1); then
+      break
+    fi
+    if [[ $service_info == *"create succeeded"* ]]; then
+      msg "deleting service $service"
+      cf delete-service -f $service
+      continue
+    fi
+    if [[ $service_info == *"create in progress"* ]]; then
+      die "cannot delete service $service; it is in the process of being created"
+    fi
+    count=$((count+1))
+    if [[ $service_info == *"delete in progress"* ]]; then
+      msg "waiting for service $service to be deleted ($count)"
+    else
+      err "unhandled status:"
+      echo $service_info
+    fi
+    sleep 1
+  done
 }
+
+# vim: et sw=2 sts=2

--- a/cloudfoundry/mysql/destroy.sh
+++ b/cloudfoundry/mysql/destroy.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-if (cf services | grep "^mysql"); then
-  cf ds mysql -f
-fi
+source ../common.sh
 
-if (cf services | grep "^mysql_skipper"); then
-  cf ds mysql_skipper -f
-fi
+destroy_service "mysql"
+
+destroy_service "mysql_skipper"


### PR DESCRIPTION
Making service creation/deletion blocking helps to ensure:
 * necessary services are available to subsequent steps
 * services are removed prior to test job exit

This PR also begins to help with differentiating stdout logs.
