### PR TITLE
allow overriding cf service status poll/delay

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -116,7 +116,7 @@ you have that installed and configured properly.
 When cleaning up, the script will only remove docker images, if you are using a local service like redis or mysql
 the script will not do anything to it
 
-== Cloudfoundry
+== CloudFoundry
 
 === Pre-requisites
 On Cloudfoundry, make sure you have the following environment variables exported. We will not include them on any files
@@ -137,6 +137,14 @@ You can override service names and plans by either exporting or changing the fol
 * RABBIT_PLAN_NAME
 * REDIS_SERVICE_NAME
 * REDIS_PLAN_NAME
+
+The creation and deletion of services are implemented as blocking functions, i.e. a test job will wait, for instance,
+during setup until a service is created before continuing.  After requesting CloudFoundry to create or delete a service, these functions
+periodically poll until the request has been fully met.  The defaults for the  number of polls and the delay between
+polling can be overridden using the following properties:
+
+* SCDFAT_RETRY_MAX _(default 100, set to <0 for no max)_
+* SCDFAT_RETRY_SLEEP _(in seconds, default 5)_
 
 == Kubernetes (GKE)
 

--- a/cloudfoundry/common.sh
+++ b/cloudfoundry/common.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-MAX_COUNT=250
+SCDFAT_RETRY_SLEEP=${SCDFAT_RETRY_SLEEP:-5}
+SCDFAT_RETRY_MAX=${SCDFAT_RETRY_MAX:-100}      # set to <0 for no max (infinite)
 
 MSG_COLOR=
 ERR_COLOR=
@@ -49,12 +50,12 @@ function create_service() {
       die "cannot create service $service; it is in the process of being deleted"
     fi
     count=$((count+1))
-    if [ $count -gt $MAX_COUNT ]; then
-      die "maximum retries exceeded ($MAX_COUNT)"
+    if [ $SCDFAT_RETRY_MAX -ge 0 ] && [ $count -gt $SCDFAT_RETRY_MAX ]; then
+      die "maximum retries exceeded ($SCDFAT_RETRY_MAX)"
     fi
     if [[ $service_info == *"create in progress"* ]]; then
-      msg "waiting for service $service to be created ($count)"
-      sleep 1
+      msg "waiting for service $service to be created, sleeping ${SCDFAT_RETRY_SLEEP}s ($count of $SCDFAT_RETRY_MAX)"
+      sleep $SCDFAT_RETRY_SLEEP
       continue
     fi
     err "unhandled status:"
@@ -80,12 +81,12 @@ function destroy_service() {
       die "cannot delete service $service; it is in the process of being created"
     fi
     count=$((count+1))
-    if [ $count -gt $MAX_COUNT ]; then
-      die "maximum retries exceeded ($MAX_COUNT)"
+    if [ $SCDFAT_RETRY_MAX -ge 0 ] && [ $count -gt $SCDFAT_RETRY_MAX ]; then
+      die "maximum retries exceeded ($SCDFAT_RETRY_MAX)"
     fi
     if [[ $service_info == *"delete in progress"* ]]; then
-      msg "waiting for service $service to be deleted ($count)"
-      sleep 1
+      msg "waiting for service $service to be deleted, sleeping ${SCDFAT_RETRY_SLEEP}s ($count of $SCDFAT_RETRY_MAX)"
+      sleep $SCDFAT_RETRY_SLEEP
       continue
     fi
     err "unhandled status:"


### PR DESCRIPTION
While the defaults are good for Bamboo/CI, in local development a shorter polly delay and a larger/infinite max poll are useful.