### PR TITLE
Fix woodchuck test

### DIFF
--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -364,7 +364,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		logger.info("Looking for '" + StringUtils.arrayToCommaDelimitedString(entries) + "' in logfile for "
 				+ app.getDefinition());
 		final long timeout = System.currentTimeMillis() + (configurationProperties.getMaxWaitTime() * 1000);
-		List<Log> logs = new ArrayList<>(0);
+		List<Log> logs = new ArrayList<>();
 		LogRetriever logRetriever = isCloudFoundry() ? new CloudFoundryLogRetriever(app) : new DefaultLogRetriever(app);
 
 		while (System.currentTimeMillis() < timeout) {
@@ -465,7 +465,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 
 		@Override
 		List<Log> retrieveLogs() {
-		    List<Log> logs = new ArrayList<>(1);
+		    List<Log> logs = new ArrayList<>();
 			for (String appInstance : app.getInstanceUrls().keySet()) {
 				logger.info("Requesting log for app " + appInstance);
 				Log log = new Log();
@@ -518,7 +518,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 			} else {
 				logger.error("ERROR: system command exceeded maximum wait time (" + maxWait + "s)");
 			}
-			List<Log> logs = new ArrayList<>(1);
+			List<Log> logs = new ArrayList<>();
 			logs.add(log);
 			return logs;
 		}

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -24,9 +24,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -364,7 +364,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		logger.info("Looking for '" + StringUtils.arrayToCommaDelimitedString(entries) + "' in logfile for "
 				+ app.getDefinition());
 		final long timeout = System.currentTimeMillis() + (configurationProperties.getMaxWaitTime() * 1000);
-		List<Log> logs = null;
+		List<Log> logs = new ArrayList<>(0);
 		LogRetriever logRetriever = isCloudFoundry() ? new CloudFoundryLogRetriever(app) : new DefaultLogRetriever(app);
 
 		while (System.currentTimeMillis() < timeout) {
@@ -393,7 +393,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		}
 
 		logger.error("ERROR: Couldn't find '" + StringUtils.arrayToCommaDelimitedString(entries) + "; details below");
-		if (logs == null || logs.size() == 0) {
+		if (logs.isEmpty()) {
 			logger.error("ERROR: No logs retrieved");
 		}
 		else {
@@ -470,7 +470,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 
 		@Override
 		List<Log> retrieveLogs() {
-		    List<Log> logs = new LinkedList<>();
+		    List<Log> logs = new ArrayList<>(1);
 			for (String appInstance : app.getInstanceUrls().keySet()) {
 				logger.info("Requesting log for app " + appInstance);
 				Log log = new Log();
@@ -518,7 +518,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 			} else {
 				logger.error("ERROR: system command exceeded maximum wait time (" + maxWait + "s)");
 			}
-			List<Log> logs = new LinkedList<>();
+			List<Log> logs = new ArrayList<>(1);
 			logs.add(log);
 			return logs;
 		}

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -24,7 +24,11 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -313,6 +317,9 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		}
 		catch (HttpClientErrorException e) {
 			logger.info("Failed to access logfile from '" + logFileUrl + "' due to : " + e.getMessage());
+		}
+		catch (Exception e) {
+			logger.warn("Error while trying to access logfile from '" + logFileUrl + "' due to : " + e);
 		}
 		return log;
 	}

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -441,7 +441,7 @@ public abstract class AbstractStreamTests implements InitializingBean {
 		}
 	}
 
-	class Log {
+	private class Log {
 		String source;
 		String content;
 	}


### PR DESCRIPTION
Fixes the woodchuck test on CloudFoundry by using the system command `cf logs ...` to fetch app logs rather than using HTTP requests.  At some point in more recent PCF releases, using HTTP to fetch logs on CloudFoundry would at times fail, seemingly due to all the HTTP requests being routed to a single app instance rather than round-robin to all instances. Using the system command works around this behavior since it fetches log content that contains the logs from all the app instances.