### PR TITLE
URL Cleanup

### DIFF
--- a/etc/checkstyle/checkstyle-header.txt
+++ b/etc/checkstyle/checkstyle-header.txt
@@ -5,7 +5,7 @@
 ^\Q * you may not use this file except in compliance with the License.\E$
 ^\Q * You may obtain a copy of the License at\E$
 ^\Q *\E$
-^\Q *      http://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
 ^\Q *\E$
 ^\Q * Unless required by applicable law or agreed to in writing, software\E$
 ^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/AbstractPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/AbstractPlatformHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Application.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/DefaultPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/DefaultPlatformHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/KubernetesPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/KubernetesPlatformHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalPlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/LocalPlatformHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelper.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/StreamDefinition.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/StreamDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractStreamTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/HttpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/NamedChannelTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/NamedChannelTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TickTockTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TimestampTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TimestampTaskTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/TransformTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/WoodChuckTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/WoodChuckTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/ApplicationTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/LogTestNameRule.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/LogTestNameRule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelperTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/util/PlatformHelperTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 20 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).