### PR TITLE
Implement KubernetesLogRetriever and decrease probe delays

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -272,7 +272,7 @@ function run_tests() {
   if [  -z "$skipCloudConfig" ]; then
     skipCloudConfig="false"
   fi
-  eval "./mvnw -B -Dspring.profiles.active=blah -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM -DSKIP_CLOUD_CONFIG=$skipCloudConfig test surefire-report:report"
+  eval "./mvnw -B -Dspring.profiles.active=blah -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM -DNAMESPACE=$KUBERNETES_NAMESPACE -DSKIP_CLOUD_CONFIG=$skipCloudConfig test surefire-report:report"
 }
 
 # ======================================= FUNCTIONS END =======================================

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -42,6 +42,8 @@ public class TestConfigurationProperties {
 
 	private String platformSuffix = "local.pcfdev.io";
 
+	private String namespace = "default";
+
 	private String streamRegistrationResource = "https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.BUILD-SNAPSHOT/spring-cloud-stream-app-descriptor-Celsius.BUILD-SNAPSHOT.stream-apps-rabbit-maven";
 
 	private String taskRegistrationResource = "https://repo.spring.io/libs-release/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Elston.RELEASE/spring-cloud-task-app-descriptor-Elston.RELEASE.task-apps-maven";
@@ -116,5 +118,13 @@ public class TestConfigurationProperties {
 
 	public void setTaskRegistrationResource(String taskRegistrationResource) {
 		this.taskRegistrationResource = taskRegistrationResource;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
 	}
 }


### PR DESCRIPTION
This execs 'kubectl logs -n {namespace} appInstance' instead of using the actuator `logs` endpoint. This should fix intermittent failures in WoodChuckTests. 

Also reduces the probe initialDelay times, reducing stream deployment time significantly.