### PR TITLE
Fix av tv flags

### DIFF
--- a/scripts/setup.adoc
+++ b/scripts/setup.adoc
@@ -27,8 +27,6 @@ Flags:
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
 [*] -sv | --skipperVersion - set the skipper version to test (e.g. 2.4.0.BUILD-SNAPSHOT)
 [*] -dv | --dataflowVersion - set the dataflow version to test (e.g. 2.5.0.BUILD-SNAPSHOT)
-    -av | --appsVersion - set the stream app version to test (e.g. Celsius.SR2). Apps should be accessible via maven repo or docker hub.
-    -tv | --tasksVersion - set the task app version to test (e.g. Elston.RELEASE). Tasks should be accessible via maven repo or docker hub.
     -se | --schedulesEnabled - installs scheduling infrastructure and configures SCDF to use the service.
 [*] = Required arguments if environment variables are not set.
 ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,8 +14,6 @@ Flags:
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
     -sv | --skipperVersion - set the skipper version to test (e.g. 1.0.5.BUILD-SNAPSHOT)
     -dv | --dataflowVersion - set the dataflow version to test (e.g. 1.5.1.BUILD-SNAPSHOT)
-    -av | --appsVersion - set the stream app version to test (e.g. Celsius.SR2). Apps should be accessible via maven repo or docker hub.
-    -tv | --tasksVersion - set the task app version to test (e.g. Elston.RELEASE). Tasks should be accessible via maven repo or docker hub.
     -se | --schedulesEnabled - installs scheduling infrastructure and configures SCDF to use the service.
 [*] = Required arguments if environment variables are not set.
 EOF
@@ -148,14 +146,6 @@ while [[ $# > 0 ]]
 do
 key="$1"
 case ${key} in
- -av|--appsVersion)
- STREAM_APPS_VERSION="$2"
- shift
- ;;
- -tv|--tasksVersion)
- TASK_APPS_VERSION="$2"
- shift
- ;;
  -sv|--skipperVersion)
  SKIPPER_VERSION="$2"
  shift

--- a/scripts/tests.adoc
+++ b/scripts/tests.adoc
@@ -34,6 +34,8 @@ Flags:
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
     -se | --schedulesEnabled - run scheduling tests.
     -dv | --dataflowVersion - set the dataflow client version to the same as the dataflow server (e.g. 2.5.0.BUILD-SNAPSHOT)
+    -av | --appsVersion - set the stream app version to test (e.g. Celsius.SR2). Apps should be accessible via maven repo or docker hub.
+    -tv | --tasksVersion - set the task app version to test (e.g. Elston.RELEASE). Tasks should be accessible via maven repo or docker hub.
     -c  | --skipCleanup - skip the clean up phase
     -sc | --serverCleanup - run the cleanup for only SCDF and Skipper, along with the applications deployed but excluding the DB, message broker.
 ```

--- a/scripts/tests.adoc
+++ b/scripts/tests.adoc
@@ -29,8 +29,6 @@ Flags:
     -p  | --platform - define the target platform to run, defaults to local
     -b  | --binder - define the binder (i.e. RABBIT, KAFKA) defaults to RABBIT
     --tests - comma separated list of tests to run. Wildcards such as *http* are allowed (e.g. --tests TickTockTests#tickTockTests)
-    --rerunFailingTestsCount - the number of times to rerun failing tests (default is 1)
-    --skipAfterFailureCount - skip after number of tests fail (default is 1)
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
     -se | --schedulesEnabled - run scheduling tests.
     -dv | --dataflowVersion - set the dataflow client version to the same as the dataflow server (e.g. 2.5.0.BUILD-SNAPSHOT)

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -16,6 +16,8 @@ Flags:
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
     -se | --schedulesEnabled - run scheduling tests.
     -dv | --dataflowVersion - set the dataflow client version to the same as the dataflow server (e.g. 2.5.0.BUILD-SNAPSHOT)
+    -av | --appsVersion - set the stream app version to test (e.g. Celsius.SR2). Apps should be accessible via maven repo or docker hub.
+    -tv | --tasksVersion - set the task app version to test (e.g. Elston.RELEASE). Tasks should be accessible via maven repo or docker hub.
     -c  | --skipCleanup - skip the clean up phase
     -sc | --serverCleanup - run the cleanup for only SCDF and Skipper, along with the applications deployed but excluding the DB, message broker.
 [*] = Required arguments
@@ -61,6 +63,14 @@ key="$1"
 case ${key} in
  -p|--platform)
  PLATFORM="$2"
+ shift
+ ;;
+-av|--appsVersion)
+ STREAM_APPS_VERSION="$2"
+ shift
+ ;;
+ -tv|--tasksVersion)
+ TASK_APPS_VERSION="$2"
  shift
  ;;
 -b|--binder)

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -11,8 +11,6 @@ Flags:
     -p  | --platform - define the target platform to run, defaults to local
     -b  | --binder - define the binder (i.e. RABBIT, KAFKA) defaults to RABBIT
     --tests - comma separated list of tests to run. Wildcards such as *http* are allowed (e.g. --tests TickTockTests#tickTockTests)
-    --rerunFailingTestsCount - the number of times to rerun failing tests (default is 1)
-    --skipAfterFailureCount - skip after number of tests fail (default is 1)
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF
     -se | --schedulesEnabled - run scheduling tests.
     -dv | --dataflowVersion - set the dataflow client version to the same as the dataflow server (e.g. 2.5.0.BUILD-SNAPSHOT)
@@ -39,8 +37,7 @@ function run_tests() {
 
   log_skipper_versions
 
-  eval "./mvnw -B -Dspring.profiles.active=blah -Dtest=$TESTS -Dsurefire.rerunFailingTestsCount=$rerunFailingTestsCount \\
-  -Dsurefire.skipAfterFailureCount=$skipAfterFailureCount -DPLATFORM_TYPE=$PLATFORM -DNAMESPACE=$KUBERNETES_NAMESPACE \\
+  eval "./mvnw -B -Dspring.profiles.active=blah -Dtest=$TESTS -DPLATFORM_TYPE=$PLATFORM -DNAMESPACE=$KUBERNETES_NAMESPACE \\
   -Ddataflow.version=$DATAFLOW_VERSION -DSKIP_CLOUD_CONFIG=$skipCloudConfig test surefire-report:report"
 }
 
@@ -83,14 +80,6 @@ case ${key} in
  ;;
  --tests)
  TESTS="$2"
- shift
- ;;
---skipAfterFailureCount)
- skipAfterFailureCount="$2"
- shift
- ;;
---rerunFailingTestsCount)
- rerunFailingTestsCount="$2"
  shift
  ;;
  -cc|--skipCloudConfig)


### PR DESCRIPTION
The appsVersion and tasksVersion flags need to go with the test phase. 
Also backed out the skipOnFailureCount surefire settings since they don't work as expected - perhaps related to junit 5. 