### PR TITLE
Set K8s SA account the same for helm and distro files

### DIFF
--- a/kubernetes/common.sh
+++ b/kubernetes/common.sh
@@ -6,7 +6,7 @@ function distro_files_object_delete() {
   kubectl delete all,cm -l app=scdf-server --namespace $KUBERNETES_NAMESPACE --wait || true
   kubectl delete role scdf-role --namespace $KUBERNETES_NAMESPACE --wait || true
   kubectl delete rolebinding scdf-rb --namespace $KUBERNETES_NAMESPACE --wait || true
-  kubectl delete serviceaccount scdf-sa --namespace $KUBERNETES_NAMESPACE --wait || true
+  kubectl delete serviceaccount $DATAFLOW_SERVICE_ACCOUNT_NAME --namespace $KUBERNETES_NAMESPACE --wait || true
   # Clean up any stray apps
   kubectl delete all -l role=spring-app --namespace $KUBERNETES_NAMESPACE
 }

--- a/kubernetes/init/setenv.sh
+++ b/kubernetes/init/setenv.sh
@@ -18,7 +18,10 @@ fi
 if [[ -z "${KUBERNETES_NAMESPACE}" ]]; then
   export KUBERNETES_NAMESPACE='default'
 fi
-
+if [[ -z "${DATAFLOW_SERVICE_ACCOUNT_NAME}" ]]; then
+  export DATAFLOW_SERVICE_ACCOUNT_NAME=scdf-data-flow
+fi
 echo "Connecting to kubernetes cluster: ${CLUSTER_NAME} in namespace ${KUBERNETES_NAMESPACE}"
 
 kubernetes_authenticate_and_target
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -114,24 +114,6 @@ function setup() {
     run_scripts "server" "create.sh"
   popd
 }
-
-function config() {
-  pushd $PLATFORM
-    run_scripts "init" "setenv.sh"
-    pushd "binder"
-      run_scripts $BINDER "config.sh"
-    popd
-
-    run_scripts "skipper-server" "config.sh"
-
-    run_scripts "server" "config.sh"
-  popd
-}
-
-function command_exists() {
-  type "$1" &> /dev/null ;
-}
-
 # ======================================= FUNCTIONS END =======================================
 # ======================================= Main =======================================
 

--- a/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/dataflow/acceptance/test/util/TestConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Glenn Renfro
  * @author Thomas Risberg
+ * @author David Turanski
  */
 @ConfigurationProperties
 public class TestConfigurationProperties {
@@ -41,6 +42,8 @@ public class TestConfigurationProperties {
 	private String platformType = "local";
 
 	private String platformSuffix = "local.pcfdev.io";
+
+	private String dataflowServiceAccountName;
 
 	private String namespace="default";
 
@@ -125,5 +128,13 @@ public class TestConfigurationProperties {
 
 	public void setNamespace(String namespace) {
 		this.namespace = namespace;
+	}
+
+	public String getDataflowServiceAccountName() {
+		return dataflowServiceAccountName;
+	}
+
+	public void setDataflowServiceAccountName(String dataflowServiceAccountName) {
+		this.dataflowServiceAccountName = dataflowServiceAccountName;
 	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/BatchRemotePartitionTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/BatchRemotePartitionTests.java
@@ -45,8 +45,6 @@ import static org.junit.Assert.assertTrue;
 @ContextConfiguration(classes = BatchRemotePartitionTests.ConditionalCloudFoundryTestConfiguration.class)
 public class BatchRemotePartitionTests extends AbstractTaskTests {
 
-	private static final String SCDF_DATA_FLOW_SA = "scdf-data-flow";
-
 	@Autowired
 	private TestConfigurationProperties testConfigurationProperties;
 
@@ -104,7 +102,8 @@ public class BatchRemotePartitionTests extends AbstractTaskTests {
 		Map<String, String> deploymentProperties = new HashMap<>();
 		String genericPlatform = platformForPlatformType();
 		if (genericPlatform.equals("kubernetes")) {
-			deploymentProperties.put("deployer.*.kubernetes.deployment-service-account-name", SCDF_DATA_FLOW_SA);
+			deploymentProperties.put("deployer.*.kubernetes.deployment-service-account-name",
+					testConfigurationProperties.getDataflowServiceAccountName());
 		}
 		return deploymentProperties;
 	}


### PR DESCRIPTION
Fixes an issue in RemoteBatchPartitionTests which need to set the sa name to the K8s deployer. 