### PR TITLE
Clean up executions after each test

### DIFF
--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/AbstractTaskTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +53,10 @@ import org.springframework.cloud.dataflow.rest.resource.TaskExecutionResource;
 import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -127,6 +131,8 @@ public abstract class AbstractTaskTests implements InitializingBean {
 				taskDefinitionResource = taskDefinitionResourceIterator.next();
 				taskOperations.destroy(taskDefinitionResource.getName());
 			}
+
+			cleanUpExecutions();
 		}
 	}
 
@@ -331,6 +337,33 @@ public abstract class AbstractTaskTests implements InitializingBean {
 		return r -> r.getTaskName().equals(taskName);
 	}
 
+	private void cleanUpExecutions() {
+		Collection<TaskExecutionResource> taskExecutionResources  = taskOperations.executionList().getContent();
+		List<Long> parentIds = taskExecutionResources.stream()
+				.filter(taskExecutionResource -> StringUtils.isEmpty(taskExecutionResource.getParentExecutionId()))
+				.map(TaskExecutionResource::getExecutionId)
+				.collect(Collectors.toList());
+
+		cleanUpAndRemoveDataForTaskExecutions(parentIds);
+		//Clean up any remaining
+		cleanUpAndRemoveDataForTaskExecutions(taskOperations.executionList().getContent()
+				.stream().map(TaskExecutionResource::getExecutionId).collect(Collectors.toList()));
+	}
+
+	private void cleanUpAndRemoveDataForTaskExecutions(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return;
+		}
+		URI uri = new DefaultUriBuilderFactory(configurationProperties.getServerUri())
+				.builder()
+				.pathSegment("tasks","executions")
+				.pathSegment(StringUtils.collectionToCommaDelimitedString(ids))
+				.queryParam("action","CLEANUP,REMOVE_DATA")
+				.build();
+
+		restTemplate.delete(uri);
+	}
+
 	/**
 	 * Creates a unique schedule name from a UUID from an existing task definition.
 	 *
@@ -410,8 +443,4 @@ public abstract class AbstractTaskTests implements InitializingBean {
 		return jobExecutionPagedResources.getContent();
 	}
 
-	public enum TaskTestTypes {
-		TIMESTAMP,
-		CORE
-	}
 }

--- a/src/test/java/org/springframework/cloud/dataflow/acceptance/test/ComposedTaskTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/acceptance/test/ComposedTaskTests.java
@@ -61,6 +61,7 @@ public class ComposedTaskTests extends AbstractTaskTests {
 		assertParentTaskExecution(taskDefinitionName, 0, 2, 2);
 	}
 
+
 	private void assertTaskExecutions(String taskDefinitionName,
 			int expectedExitCode, int expectedCount) {
 		assertTrue(waitForTaskToComplete(taskDefinitionName + "-a", expectedCount));


### PR DESCRIPTION
This cleans up task execution tables so we can retain mysql service between runs to save time.