### PR TITLE
Add PLATFORM_FOLDER (-pf) parameter

### DIFF
--- a/scripts/clean.adoc
+++ b/scripts/clean.adoc
@@ -24,6 +24,7 @@ USAGE: clean.sh -p <PLATFORM> -b <BINDER> [--schedulesEnabled]
 
 Flags:
 -p  | --platform - define the target platform to clean, defaults to local
+-pf | --platformFolder - folder containing the scripts for installing the platform. Defaults to 'platform'
 -b  | --binder - define the binder to clean (i.e. RABBIT, KAFKA) defaults to RABBIT
 -sc | --serverCleanup - run the cleanup for the SCDF/Skipper (along with the applications deployed but excluding the DB, message broker)
 -se | --schedulesEnabled - cleans scheduling infrastructure if installed.

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -10,8 +10,8 @@ USAGE: clean.sh -p <PLATFORM> -b <BINDER> [--schedulesEnabled --serverCleanup]
   This will cleanup any existing resources on the platform
 
 Flags:
-
 -p  | --platform - define the target platform to clean, defaults to local
+-pf | --platformFolder - folder containing the scripts for installing the platform. Defaults to 'platform'
 -b  | --binder - define the binder (i.e. RABBIT, KAFKA) defaults to RABBIT
 -sc | --serverCleanup - run the cleanup for only SCDF and Skipper, along with the applications deployed but excluding the DB, message broker.
 -se | --schedulesEnabled - cleans the scheduling infrastructure.
@@ -23,7 +23,7 @@ function tear_down() {
 
   tear_down_servers
 
-  pushd $PLATFORM
+  pushd $PLATFORM_FOLDER
     run_scripts "mysql" "destroy.sh"
     if [ "$schedulesEnabled" ]; then
         run_scripts "scheduler" "destroy.sh"
@@ -40,7 +40,7 @@ function tear_down() {
 }
 
 function tear_down_servers() {
-  pushd $PLATFORM
+  pushd $PLATFORM_FOLDER
     echo "Clean up servers"
     run_scripts "server" "destroy.sh"
 
@@ -69,11 +69,15 @@ case ${key} in
  PLATFORM="$2"
  shift
  ;;
--b|--binder)
+ -pf|--platformFolder)
+ PLATFORM_FOLDER="$2"
+ shift
+ ;;
+ -b|--binder)
  BINDER="$2"
  shift
  ;;
--se|--schedulesEnabled)
+ -se|--schedulesEnabled)
  schedulesEnabled="true"
  ;;
  -sc|--serverCleanup)
@@ -92,11 +96,12 @@ esac
 shift
 done
 
+[[ -z "${PLATFORM_FOLDER}" ]] && PLATFORM_FOLDER=$PLATFORM
 
-[[ ! -d "$PLATFORM" ]] && { echo "$(basename $BASH_SOURCE) $PLATFORM is an invalid platform"; exit 1; }
-[[ ! -d "$PLATFORM/binder/$BINDER" ]] && { echo "$(basename $BASH_SOURCE) $BINDER is an invalid binder for $PLATFORM platform"; exit 1; }
+[[ ! -d "$PLATFORM_FOLDER" ]] && { echo "$(basename $BASH_SOURCE) $PLATFORM_FOLDER is an invalid platform folder"; exit 1; }
+[[ ! -d "$PLATFORM_FOLDER/binder/$BINDER" ]] && { echo "$(basename $BASH_SOURCE) $BINDER is an invalid binder for $PLATFORM_FOLDER platform folder"; exit 1; }
 
-pushd $PLATFORM
+pushd $PLATFORM_FOLDER
     run_scripts "init" "setenv.sh"
 popd
 

--- a/scripts/setup.adoc
+++ b/scripts/setup.adoc
@@ -1,6 +1,6 @@
 = Spring Cloud Data Flow Acceptance Tests - Setup =
 
-This script configures, deploys, and verifies the acceptence test environment is ready to run the tests.
+This script configures, deploys, and verifies the acceptance test environment is ready to run the tests.
 
 == How to run it
 
@@ -17,11 +17,12 @@ Alternately, you can run it standalone from the project root:
 ```
 
 ```
-USAGE: setup.sh -p <PLATFORM> -b <BINDER> [-d -cc -sv -dv -se]
+USAGE: setup.sh -p <PLATFORM> -b <BINDER> [-pf -d -cc -sv -dv -se]
   Set up the test environment.
 
 Flags:
     -p  | --platform - define the target platform to run, defaults to local
+    -pf | --platformFolder - folder containing the scripts for installing the platform. Defaults to 'platform'
     -b  | --binder - define the binder (i.e. RABBIT, KAFKA) defaults to RABBIT
     -d  | --doNotDownload - skip the downloading of the SCDF/Skipper servers
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF

--- a/scripts/tests.adoc
+++ b/scripts/tests.adoc
@@ -22,11 +22,12 @@ Alternately, you can run it standalone from the project root:
 ```
 
 ```
-USAGE: tests.sh -p <PLATFORM> -b <BINDER> [-se -cc -av- tv --tests ...]
+USAGE: tests.sh -p <PLATFORM> -b <BINDER> [-pf -se -cc -av- tv -c -sc --tests ...]
   Run the acceptance tests.
 
 Flags:
     -p  | --platform - define the target platform to run, defaults to local
+    -pf | --platformFolder - folder containing the scripts for installing the platform. Defaults to 'platform'
     -b  | --binder - define the binder (i.e. RABBIT, KAFKA) defaults to RABBIT
     --tests - comma separated list of tests to run. Wildcards such as *http* are allowed (e.g. --tests TickTockTests#tickTockTests)
     -cc | --skipCloudConfig - skip Cloud Config server tests for CF

--- a/scripts/utility-functions.sh
+++ b/scripts/utility-functions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # ======================================= DEFAULTS ============================================
 [[ -z "${PLATFORM}" ]] && PLATFORM=local
+[[ -z "${PLATFORM_FOLDER}" ]] && PLATFORM_FOLDER=$PLATFORM
 [[ -z "${BINDER}" ]] && BINDER=rabbit
 WAIT_TIME="${WAIT_TIME:-5}"
 RETRIES="${RETRIES:-60}"
@@ -108,7 +109,7 @@ function command_exists() {
 }
 
 function config() {
-  pushd $PLATFORM
+  pushd $PLATFORM_FOLDER
     run_scripts "init" "setenv.sh"
     pushd "binder"
       run_scripts $BINDER "config.sh"


### PR DESCRIPTION
 Add new '-pf | paltformFolder' parameter and related PLATFORM_FOLDER variable to hold the path of the platform installation scripts.
 To ensure backward compatibility if the PLATFORM_FOLDER is not provided it defaults to the PLATFORM.