### PR TITLE
Updated the docs and scripts to fix a couple of hiccups

### DIFF
--- a/src/local/README.adoc
+++ b/src/local/README.adoc
@@ -52,7 +52,7 @@ https://tanzu.vmware.com/mission-control[Tanzu Mission Control]
 For local development you need control of the containers used in the local environment. In order to ensure to manage the specific versions of data flow and skipper containers you can set SKIPPER_VERSION and DATAFLOW_VERSION environmental variable and then invoke `./src/local/pull-dataflow.sh` and `./src/local/pull-skipper.sh`
 
 If you want to use a locally built application you can invoke
-`./src/loca/build-skipper-image.sh` or `./src/local/build-dataflow.sh`
+`./src/local/build-skipper-image.sh` or `./src/local/build-dataflow.sh`
 
 
 == Create Configure k8s environment
@@ -73,7 +73,7 @@ use-gke.sh <cluster-name> [<namespace>]
 
 NOTE: <driver> must be one of `kvm2`, `docker`, `vmware`, `virtualbox`, `vmwarefusion` or `hyperkit`. `docker` is the recommended option for local development.
 
-Since these scripts export environmental variable they need to be executes as in the following example:
+Since these scripts export environmental variable they need to be executed as in the following example:
 
 [source,shell]
 ....
@@ -111,7 +111,7 @@ export BROKER=<broker> # <1>
 ....
 export DATABASE=<database> # <1>
 ....
-<1> <database> one of `mariadb` or `postgresql`
+<1> Currently only `mariadb` is supported and is the default.   In the future we will add `postgresql`
 
 [source,shell]
 ....

--- a/src/local/build-skipper-image.sh
+++ b/src/local/build-skipper-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SCDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 if [ "$SKIPPER_VERSION" = "" ]; then
-  SKIPPER_VERSION=2.10.0-SNAPSHOT
+  SKIPPER_VERSION=2.9.0-SNAPSHOT
 fi
 
 pushd "$SCDIR/../../../spring-cloud-skipper" > /dev/null

--- a/src/local/build-skipper-image.sh
+++ b/src/local/build-skipper-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SCDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 if [ "$SKIPPER_VERSION" = "" ]; then
-  SKIPPER_VERSION=2.9.0-SNAPSHOT
+  SKIPPER_VERSION=2.10.0-SNAPSHOT
 fi
 
 pushd "$SCDIR/../../../spring-cloud-skipper" > /dev/null

--- a/src/local/deploy-scdf.sh
+++ b/src/local/deploy-scdf.sh
@@ -62,7 +62,7 @@ if [ "$DATAFLOW_VERSION" = "" ]; then
 fi
 
 if [ "$SKIPPER_VERSION" = "" ]; then
-  SKIPPER_VERSION=2.10.0-SNAPSHOT
+  SKIPPER_VERSION=2.9.0-SNAPSHOT
 fi
 
 if [ "$SCDF_PRO_VERSION" = "" ]; then

--- a/src/local/deploy-scdf.sh
+++ b/src/local/deploy-scdf.sh
@@ -29,6 +29,7 @@ case $DATABASE in
     ;;
   *)
     echo "DATABASE=$DATABASE not supported"
+    exit 1;
     ;;
 esac
 
@@ -61,7 +62,7 @@ if [ "$DATAFLOW_VERSION" = "" ]; then
 fi
 
 if [ "$SKIPPER_VERSION" = "" ]; then
-  SKIPPER_VERSION=2.9.0-SNAPSHOT
+  SKIPPER_VERSION=2.10.0-SNAPSHOT
 fi
 
 if [ "$SCDF_PRO_VERSION" = "" ]; then
@@ -80,7 +81,7 @@ if [ "$K8S_DRIVER" != "tmc" ] && [ "$K8S_DRIVER" != "gke" ] ; then
     sh "$SCDIR/load-image.sh" "mariadb" "10.4"
     ;;
   "postgres" | "postgresql")
-    sh "$SCDIR/load-image.sh" "postgresql" "10"
+    sh "$SCDIR/load-image.sh" "postgres" "10"
     ;;
   *)
     echo "DATABASE=$DATABASE not supported"


### PR DESCRIPTION
If the DB specified is invalid the script terminates.   It used to continue with the assumption that it was mariadb eventhough I had specified postgres

Updated postgres docker image.   The original was incorrect.

I also had to change the rabbitmq version because the one specified did not work on M1.   But I did not include that in this PR .   We can discuss.
